### PR TITLE
Add past definition versions

### DIFF
--- a/app.js
+++ b/app.js
@@ -47,7 +47,7 @@ router
 // Mount router & definition middleware twice, once at the root level
 // and once under a slug for the definition version/id
 app
-  .use(['/', '/:definition(\\d+)'], definitions)
+  .use(['/', '/:definition(\\d+)'], definitions) // :definition(\\d+) matches one or more digits
   .use(['/', '/:definition(\\d+)'], router)
 
 // Catches 404 and forwards to error handler

--- a/app.js
+++ b/app.js
@@ -52,7 +52,7 @@ app.use((req, res, next) => {
 app.use((err, req, res, next) => {
   const status = err.status || 500;
   res.locals.error = {};
-  if (process.env.NODE_ENV === 'development') {
+  if (process.env.NODE_ENV !== 'production') {
     res.locals.error =  err;
     res.locals.error.stack = cleanStack(err.stack, { pretty: true, })      
   }

--- a/app.js
+++ b/app.js
@@ -6,6 +6,8 @@ const cookieParser = require('cookie-parser');
 const bodyParser = require('body-parser');
 const cleanStack = require('clean-stack');
 
+const router = express.Router();
+
 // loads variables in `.env` file into `process.env` global
 require('dotenv').config()
 if (!process.env.ARENA_CHANNEL_ID) {
@@ -17,6 +19,7 @@ const channels = require('./routes/channels');
 const blocks = require('./routes/blocks');
 
 const helpers = require('./middleware/helpers');
+const definitions = require('./middleware/definitions');
 
 const app = express();
 
@@ -35,11 +38,17 @@ app
   .use(express.static(path.join(__dirname, 'public')))
   .use(helpers);
 
-// Mount routers
-app
+// Setup view router
+router
   .use('/', index)
   .use('/channels', channels)
   .use('/blocks', blocks);
+
+// Mount router & definition middleware twice, once at the root level
+// and once under a slug for the definition version/id
+app
+  .use(['/', '/:definition(\\d+)'], definitions)
+  .use(['/', '/:definition(\\d+)'], router)
 
 // Catches 404 and forwards to error handler
 app.use((req, res, next) => {

--- a/middleware/definitions.js
+++ b/middleware/definitions.js
@@ -1,0 +1,36 @@
+const Arena = require('are.na');
+
+const { ARENA_CHANNEL_ID } = process.env;
+
+module.exports = async (req, res, next) => {
+  const arena = new Arena();
+  const data = await arena.channel(ARENA_CHANNEL_ID).get();
+
+  // filter the default channel's blocks by the 'Text' class
+  // and then sort by date last updated, descending
+  const definitions = data.contents
+    .filter(block => block.class == 'Text')
+    .sort((a, b) => new Date(b.updated_at) - new Date(a.updated_at));
+
+  let definition;
+  let definitionPathPrefix;
+  if (req.params.definition) {
+    definition = definitions.find(block => block.id == req.params.definition);
+    if (typeof definition == 'undefined') {
+      // if definition id is not found, go to next middleware
+      // res.locals will be missing a definition property and will be
+      // ignored by route handlers and eventually caught by 404 handler
+      next()
+    }
+    definitionPathPrefix = `/${req.params.definition}`;
+  } else {
+    definition = definitions[0];
+    definitionPathPrefix = '';
+  }
+  
+  // expose definition(s) on template locals
+  res.locals.definition = definition;
+  res.locals.definitionPathPrefix = definitionPathPrefix;
+  res.locals.definitions = definitions;
+  next();
+};

--- a/middleware/helpers.js
+++ b/middleware/helpers.js
@@ -1,3 +1,5 @@
+const format = require('date-fns/format')
+
 const shuffle = (xs) => {
   let i = xs.length, tmp, ri;
 
@@ -19,6 +21,7 @@ module.exports = (req, res, next) => {
   res.locals.helpers = {
     shuffle,
     rand,
+    dateFnsFormat: format
   };
 
   next();

--- a/package.json
+++ b/package.json
@@ -11,12 +11,12 @@
     "body-parser": "~1.18.2",
     "clean-stack": "^3.0.1",
     "cookie-parser": "~1.4.3",
+    "date-fns": "^2.17.0",
     "debug": "~3.1.0",
     "dotenv": "^8.2.0",
     "ejs": "^3.1.5",
-    "express": "~4.16.2",
+    "express": "^5.0.0-alpha.8",
     "morgan": "~1.9.0",
     "serve-favicon": "~2.4.5"
-  },
-  "devDependencies": {}
+  }
 }

--- a/public/stylesheets/app.css
+++ b/public/stylesheets/app.css
@@ -44,7 +44,7 @@ p {
   color: #333;
 }
 
-.channel-title {
+.page-title {
   margin: 3em;
   text-align: center;
   font-weight: normal;

--- a/routes/blocks.js
+++ b/routes/blocks.js
@@ -2,15 +2,11 @@ const express = require('express');
 const router = express.Router();
 const Arena = require('are.na');
 
-router.get('/:id', (req, res, next) => {
-
+router.get('/:id', async (req, res) => {
+  if (!res.locals.definition) next(); // 404
   const arena = new Arena();
-  arena
-    .block(req.params.id).get()
-    .then(data =>
-      res.render('show', data)
-    )
-    .catch(next);
+  const data = await arena.block(req.params.id).get();
+  res.render('show', data);
 });
 
 module.exports = router;

--- a/routes/channels.js
+++ b/routes/channels.js
@@ -6,9 +6,6 @@ router.get('/:id', async (req, res) => {
   if (!res.locals.definition) next(); // 404
   const arena = new Arena();
   const data = await arena.channel(req.params.id).get()
-  data.definition = req.definition;
-  data.definitionPathPrefix = req.definitionPathPrefix;
-  data.definitions = req.definitions;
   res.render('channel', data)
 });
 

--- a/routes/channels.js
+++ b/routes/channels.js
@@ -2,15 +2,14 @@ const express = require('express');
 const router = express.Router();
 const Arena = require('are.na');
 
-router.get('/:id', (req, res, next) => {
-
+router.get('/:id', async (req, res) => {
+  if (!res.locals.definition) next(); // 404
   const arena = new Arena();
-  arena
-    .channel(req.params.id).get()
-    .then(data =>
-      res.render('channel', data)
-    )
-    .catch(next);
+  const data = await arena.channel(req.params.id).get()
+  data.definition = req.definition;
+  data.definitionPathPrefix = req.definitionPathPrefix;
+  data.definitions = req.definitions;
+  res.render('channel', data)
 });
 
 module.exports = router;

--- a/routes/index.js
+++ b/routes/index.js
@@ -2,16 +2,13 @@ const express = require('express');
 const router = express.Router();
 const Arena = require('are.na');
 
-router.get('/', (req, res, next) => {
+const { ARENA_CHANNEL_ID } = process.env;
 
+router.get('/', async (req, res, next) => {
+  if (!res.locals.definition) next(); // 404
   const arena = new Arena();
-  arena
-    .channel(process.env.ARENA_CHANNEL_ID)
-    .get()
-    .then(data => {
-      return res.render('index', data)
-    })
-    .catch(next);
+  const data = await arena.channel(ARENA_CHANNEL_ID).get();
+  res.render('index', data);
 });
 
 module.exports = router;

--- a/views/channel.ejs
+++ b/views/channel.ejs
@@ -6,11 +6,11 @@
   <div class="grid">
     <% for (let block of helpers.shuffle(contents)) { %>
       <% if (block.class == 'Image') { %>
-        <%- include('partials/block-image', { block }); -%>
+        <%- include('partials/block-image', { block, definitionPathPrefix }); -%>
       <% } else if (block.class == 'Text') { %>
-        <%- include('partials/block-text', { block }); -%>
+        <%- include('partials/block-text', { block, definitionPathPrefix}); -%>
       <% } else if (block.class == 'Channel') { %>
-        <%- include('partials/block-channel-title', { block }); -%>
+        <%- include('partials/block-channel-title', { block, definitionPathPrefix}); -%>
       <% } %>
     <% } %>
   </div>

--- a/views/channel.ejs
+++ b/views/channel.ejs
@@ -3,11 +3,11 @@
   <h1 class="channel-title"><%= title %></h1>
   <div class="grid">
     <% for (let block of helpers.shuffle(contents)) { %>
-      <% if (block.image) { %>
+      <% if (block.class == 'Image') { %>
         <%- include('partials/block-image', { block: block }); -%>
-      <% } else if (block.content) { %>
+      <% } else if (block.class == 'Text') { %>
         <%- include('partials/block-text', { block: block }); -%>
-      <% } else { %>
+      <% } else if (block.class == 'Channel') { %>
         <%- include('partials/block-channel-title', { block: block }); -%>
       <% } %>
     <% } %>

--- a/views/channel.ejs
+++ b/views/channel.ejs
@@ -1,14 +1,16 @@
 <%- include('partials/header'); -%>
 <main id="channel">
-  <h1 class="channel-title"><%= title %></h1>
+  <h1 class="page-title">
+    <%= title %>
+  </h1>
   <div class="grid">
     <% for (let block of helpers.shuffle(contents)) { %>
       <% if (block.class == 'Image') { %>
-        <%- include('partials/block-image', { block: block }); -%>
+        <%- include('partials/block-image', { block }); -%>
       <% } else if (block.class == 'Text') { %>
-        <%- include('partials/block-text', { block: block }); -%>
+        <%- include('partials/block-text', { block }); -%>
       <% } else if (block.class == 'Channel') { %>
-        <%- include('partials/block-channel-title', { block: block }); -%>
+        <%- include('partials/block-channel-title', { block }); -%>
       <% } %>
     <% } %>
   </div>

--- a/views/error.ejs
+++ b/views/error.ejs
@@ -1,6 +1,8 @@
 <%- include('partials/header'); -%>
 <main id="error">
-  <h1 class="error-message">Error <%= status %></h1>
-  <pre class="error-trace"><%= error.stack %></pre>
+  <h1 class="page-title">Error <%= status %></h1>
+  <pre class="error-trace">
+    <%= error.stack %>
+  </pre>
 </main>
 <%- include('partials/footer'); -%>

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -1,12 +1,13 @@
 <%- include('partials/header'); -%>
 <main id="index">
-  <h1 class="channel-title"><%= title %></h1>
+  <h1 class="page-title">
+    <%= title %>
+  </h1>
   <div class="grid">
+    <%- include('partials/definition', { block: definition, definitionPathPrefix, definitions }); -%>
     <% for (let block of helpers.shuffle(contents)) { %>
-      <% if (block.id == '10694608') { %>
-        <%- include('partials/definition', { block: block }); -%>
-      <% } else if (block.class == 'Channel') { %>
-        <%- include('partials/block-channel-title', { block: block }); -%>
+      <% if (block.class == 'Channel') { %>
+        <%- include('partials/block-channel-title', { block, definitionPathPrefix }); -%>
       <% } %>
     <% } %>
   </div>

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -3,10 +3,9 @@
   <h1 class="channel-title"><%= title %></h1>
   <div class="grid">
     <% for (let block of helpers.shuffle(contents)) { %>
-      <%- include('partials/definition', { block: block }); -%>
-      <% if (block.image) { %>
-        <%- include('partials/block-image', { block: block }); -%>
-      <% } else { %>
+      <% if (block.id == '10694608') { %>
+        <%- include('partials/definition', { block: block }); -%>
+      <% } else if (block.class == 'Channel') { %>
         <%- include('partials/block-channel-title', { block: block }); -%>
       <% } %>
     <% } %>

--- a/views/partials/block-channel-title.ejs
+++ b/views/partials/block-channel-title.ejs
@@ -1,6 +1,6 @@
 <a
   class="grid-block"
-  href="<%= `/channels/${block.id}` %>"
+  href="<%= `${definitionPathPrefix}/channels/${block.id}` %>"
   style="<%= `width: ${helpers.rand(100, 400)}px;` %>"
 >
   <h3 class="block-title"><%= block.title %></h1>

--- a/views/partials/block-image.ejs
+++ b/views/partials/block-image.ejs
@@ -1,6 +1,6 @@
 <a
   class="grid-block"
-  href="<%= `/blocks/${block.id}` %>"
+  href="<%= `${definitionPathPrefix}/blocks/${block.id}` %>"
   style="<%= `width: ${helpers.rand(100, 400)}px;` %>"
 >
   <img src="<%= block.image.display.url %>" />

--- a/views/partials/block-text.ejs
+++ b/views/partials/block-text.ejs
@@ -1,6 +1,6 @@
 <a
   class="grid-block"
-  href="<%= `/blocks/${block.id}` %>"
+  href="<%= `${definitionPathPrefix}/blocks/${block.id}` %>"
   style="<%= `width: ${helpers.rand(100, 400)}px;` %>"
 >
   <div class="block-content"><%- block.content_html %></div>

--- a/views/partials/definition.ejs
+++ b/views/partials/definition.ejs
@@ -1,6 +1,17 @@
-<a
-  class="stamp"
-  href="<%= `/blocks/${block.id}` %>"
->
-  <div><%- block.content_html %></div>
-</a>
+<div class="stamp">
+  <a
+    href="<%= `${definitionPathPrefix}/blocks/${block.id}` %>"
+  >
+    <div>
+      <%- block.content_html %>
+    </div>
+  </a>
+  <p>
+    Versions: 
+    <% for (let definition of definitions) { %>
+      <a href="<%= `/${definition.id}/` %>">
+        <%= helpers.dateFnsFormat(new Date(definition.updated_at), 'MM/dd/yyyy') %>
+      </a>
+    <% } %>
+  </p>
+</div>

--- a/views/show.ejs
+++ b/views/show.ejs
@@ -1,5 +1,8 @@
 <%- include('partials/header'); -%>
 <main id="show">
+  <h1 class="page-title">
+    <%= title %>
+  </h1>
   <div class="block">
     <% if (image) { %>
       <img src="<%= image.large.url %>" />
@@ -10,8 +13,7 @@
         <%- content_html %>
       </div>
     <% } %>
-
-</div>
+  </div>
   <div class="block-metadata">
     <div class="block-metadata-title"><%= title %></div>
     <% if (description_html) { %>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,12 +2,13 @@
 # yarn lockfile v1
 
 
-accepts@~1.3.4:
-  version "1.3.4"
-  resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.4.tgz"
+accepts@~1.3.7:
+  version "1.3.7"
+  resolved "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz"
+  integrity sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==
   dependencies:
-    mime-types "~2.1.16"
-    negotiator "0.6.1"
+    mime-types "~2.1.24"
+    negotiator "0.6.2"
 
 ansi-styles@^3.2.1:
   version "3.2.1"
@@ -23,9 +24,10 @@ are.na@^0.0.7:
     axios "^0.17.1"
     qs "^6.5.1"
 
-array-flatten@1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/array-flatten/-/array-flatten-1.1.1.tgz"
+array-flatten@2.1.1:
+  version "2.1.1"
+  resolved "https://registry.npmjs.org/array-flatten/-/array-flatten-2.1.1.tgz"
+  integrity sha1-Qmu52oQJDBg42BLIFQryCoMx4pY=
 
 async@0.9.x:
   version "0.9.2"
@@ -50,7 +52,23 @@ basic-auth@~2.0.0:
   dependencies:
     safe-buffer "5.1.1"
 
-body-parser@1.18.2, body-parser@~1.18.2:
+body-parser@1.19.0:
+  version "1.19.0"
+  resolved "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz"
+  integrity sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==
+  dependencies:
+    bytes "3.1.0"
+    content-type "~1.0.4"
+    debug "2.6.9"
+    depd "~1.1.2"
+    http-errors "1.7.2"
+    iconv-lite "0.4.24"
+    on-finished "~2.3.0"
+    qs "6.7.0"
+    raw-body "2.4.0"
+    type-is "~1.6.17"
+
+body-parser@~1.18.2:
   version "1.18.2"
   resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.18.2.tgz"
   dependencies:
@@ -77,6 +95,11 @@ bytes@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.0.0.tgz"
 
+bytes@3.1.0:
+  version "3.1.0"
+  resolved "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz"
+  integrity sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==
+
 chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz"
@@ -88,7 +111,7 @@ chalk@^2.4.2:
 
 clean-stack@^3.0.1:
   version "3.0.1"
-  resolved "https://registry.yarnpkg.com/clean-stack/-/clean-stack-3.0.1.tgz#155bf0b2221bf5f4fba89528d24c5953f17fe3a8"
+  resolved "https://registry.yarnpkg.com/clean-stack/-/clean-stack-3.0.1.tgz"
   integrity sha512-lR9wNiMRcVQjSB3a7xXGLuz4cr4wJuuXlaAEbRutGowQTmlp7R72/DOgN21e8jdwblMWl9UOJMJXarX94pzKdg==
   dependencies:
     escape-string-regexp "4.0.0"
@@ -110,9 +133,12 @@ concat-map@0.0.1:
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz"
   integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
 
-content-disposition@0.5.2:
-  version "0.5.2"
-  resolved "https://registry.yarnpkg.com/content-disposition/-/content-disposition-0.5.2.tgz"
+content-disposition@0.5.3:
+  version "0.5.3"
+  resolved "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.3.tgz"
+  integrity sha512-ExO0774ikEObIAEV9kDo50o+79VCUdEB6n6lzKgGwupcVeRlhrj3qGAfwq8G6uBJjkqLrhT0qEYFcWng8z1z0g==
+  dependencies:
+    safe-buffer "5.1.2"
 
 content-type@~1.0.4:
   version "1.0.4"
@@ -133,13 +159,23 @@ cookie@0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.3.1.tgz"
 
+cookie@0.4.0:
+  version "0.4.0"
+  resolved "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz"
+  integrity sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==
+
+date-fns@^2.17.0:
+  version "2.17.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.17.0.tgz#afa55daea539239db0a64e236ce716ef3d681ba1"
+  integrity sha512-ZEhqxUtEZeGgg9eHNSOAJ8O9xqSgiJdrL0lzSSfMF54x6KXWJiOH/xntSJ9YomJPrYH/p08t6gWjGWq1SDJlSA==
+
 debug@2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz"
   dependencies:
     ms "2.0.0"
 
-debug@^3.1.0, debug@~3.1.0:
+debug@3.1.0, debug@^3.1.0, debug@~3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz"
   dependencies:
@@ -149,13 +185,19 @@ depd@1.1.1, depd@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.1.tgz"
 
+depd@~1.1.2:
+  version "1.1.2"
+  resolved "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz"
+  integrity sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=
+
 destroy@~1.0.4:
   version "1.0.4"
-  resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.0.4.tgz"
+  resolved "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz"
+  integrity sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=
 
 dotenv@^8.2.0:
   version "8.2.0"
-  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.2.0.tgz#97e619259ada750eea3e4ea3e26bceea5424b16a"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.2.0.tgz"
   integrity sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==
 
 ee-first@1.1.1:
@@ -169,17 +211,19 @@ ejs@^3.1.5:
   dependencies:
     jake "^10.6.1"
 
-encodeurl@~1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.1.tgz"
+encodeurl@~1.0.2:
+  version "1.0.2"
+  resolved "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz"
+  integrity sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=
 
 escape-html@~1.0.3:
   version "1.0.3"
-  resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz"
+  resolved "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz"
+  integrity sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=
 
 escape-string-regexp@4.0.0:
   version "4.0.0"
-  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz#14ba83a5d373e3d311e5afca29cf5bfad965bf34"
+  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz"
   integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
 
 escape-string-regexp@^1.0.5:
@@ -191,38 +235,40 @@ etag@~1.8.1:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz"
 
-express@~4.16.2:
-  version "4.16.2"
-  resolved "https://registry.yarnpkg.com/express/-/express-4.16.2.tgz"
+express@^5.0.0-alpha.8:
+  version "5.0.0-alpha.8"
+  resolved "https://registry.npmjs.org/express/-/express-5.0.0-alpha.8.tgz"
+  integrity sha512-PL8wTLgaNOiq7GpXt187/yWHkrNSfbr4H0yy+V0fpqJt5wpUzBi9DprAkwGKBFOqWHylJ8EyPy34V5u9YArfng==
   dependencies:
-    accepts "~1.3.4"
-    array-flatten "1.1.1"
-    body-parser "1.18.2"
-    content-disposition "0.5.2"
+    accepts "~1.3.7"
+    array-flatten "2.1.1"
+    body-parser "1.19.0"
+    content-disposition "0.5.3"
     content-type "~1.0.4"
-    cookie "0.3.1"
+    cookie "0.4.0"
     cookie-signature "1.0.6"
-    debug "2.6.9"
-    depd "~1.1.1"
-    encodeurl "~1.0.1"
+    debug "3.1.0"
+    depd "~1.1.2"
+    encodeurl "~1.0.2"
     escape-html "~1.0.3"
     etag "~1.8.1"
-    finalhandler "1.1.0"
+    finalhandler "~1.1.2"
     fresh "0.5.2"
     merge-descriptors "1.0.1"
     methods "~1.1.2"
     on-finished "~2.3.0"
-    parseurl "~1.3.2"
-    path-to-regexp "0.1.7"
-    proxy-addr "~2.0.2"
-    qs "6.5.1"
-    range-parser "~1.2.0"
-    safe-buffer "5.1.1"
-    send "0.16.1"
-    serve-static "1.13.1"
-    setprototypeof "1.1.0"
-    statuses "~1.3.1"
-    type-is "~1.6.15"
+    parseurl "~1.3.3"
+    path-is-absolute "1.0.1"
+    proxy-addr "~2.0.5"
+    qs "6.7.0"
+    range-parser "~1.2.1"
+    router "2.0.0-alpha.1"
+    safe-buffer "5.1.2"
+    send "0.17.1"
+    serve-static "1.14.1"
+    setprototypeof "1.1.1"
+    statuses "~1.5.0"
+    type-is "~1.6.18"
     utils-merge "1.0.1"
     vary "~1.1.2"
 
@@ -233,16 +279,17 @@ filelist@^1.0.1:
   dependencies:
     minimatch "^3.0.4"
 
-finalhandler@1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/finalhandler/-/finalhandler-1.1.0.tgz"
+finalhandler@~1.1.2:
+  version "1.1.2"
+  resolved "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz"
+  integrity sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==
   dependencies:
     debug "2.6.9"
-    encodeurl "~1.0.1"
+    encodeurl "~1.0.2"
     escape-html "~1.0.3"
     on-finished "~2.3.0"
-    parseurl "~1.3.2"
-    statuses "~1.3.1"
+    parseurl "~1.3.3"
+    statuses "~1.5.0"
     unpipe "~1.0.0"
 
 follow-redirects@^1.2.5:
@@ -253,7 +300,8 @@ follow-redirects@^1.2.5:
 
 forwarded@~0.1.2:
   version "0.1.2"
-  resolved "https://registry.yarnpkg.com/forwarded/-/forwarded-0.1.2.tgz"
+  resolved "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz"
+  integrity sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=
 
 fresh@0.5.2:
   version "0.5.2"
@@ -273,17 +321,52 @@ http-errors@1.6.2, http-errors@~1.6.2:
     setprototypeof "1.0.3"
     statuses ">= 1.3.1 < 2"
 
+http-errors@1.7.2:
+  version "1.7.2"
+  resolved "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz"
+  integrity sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==
+  dependencies:
+    depd "~1.1.2"
+    inherits "2.0.3"
+    setprototypeof "1.1.1"
+    statuses ">= 1.5.0 < 2"
+    toidentifier "1.0.0"
+
+http-errors@~1.7.2:
+  version "1.7.3"
+  resolved "https://registry.npmjs.org/http-errors/-/http-errors-1.7.3.tgz"
+  integrity sha512-ZTTX0MWrsQ2ZAhA1cejAwDLycFsd7I7nVtnkT3Ol0aqodaKW+0CTZDQ1uBv5whptCnc8e8HeRRJxRs0kmm/Qfw==
+  dependencies:
+    depd "~1.1.2"
+    inherits "2.0.4"
+    setprototypeof "1.1.1"
+    statuses ">= 1.5.0 < 2"
+    toidentifier "1.0.0"
+
 iconv-lite@0.4.19:
   version "0.4.19"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.19.tgz"
+
+iconv-lite@0.4.24:
+  version "0.4.24"
+  resolved "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz"
+  integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3"
 
 inherits@2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz"
 
-ipaddr.js@1.5.2:
-  version "1.5.2"
-  resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.5.2.tgz"
+inherits@2.0.4:
+  version "2.0.4"
+  resolved "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz"
+  integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
+
+ipaddr.js@1.9.1:
+  version "1.9.1"
+  resolved "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz"
+  integrity sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==
 
 is-buffer@^1.1.5:
   version "1.1.5"
@@ -311,29 +394,22 @@ methods@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz"
 
-mime-db@~1.27.0:
-  version "1.27.0"
-  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.27.0.tgz"
+mime-db@1.45.0:
+  version "1.45.0"
+  resolved "https://registry.npmjs.org/mime-db/-/mime-db-1.45.0.tgz"
+  integrity sha512-CkqLUxUk15hofLoLyljJSrukZi8mAtgd+yE5uO4tqRZsdsAJKv0O+rFMhVDRJgozy+yG6md5KwuXhD4ocIoP+w==
 
-mime-db@~1.30.0:
-  version "1.30.0"
-  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.30.0.tgz"
-
-mime-types@~2.1.15:
-  version "2.1.15"
-  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.15.tgz"
+mime-types@~2.1.24:
+  version "2.1.28"
+  resolved "https://registry.npmjs.org/mime-types/-/mime-types-2.1.28.tgz"
+  integrity sha512-0TO2yJ5YHYr7M2zzT7gDU1tbwHxEUWBCLt0lscSNpcdAfFyJOVEpRYNS7EXVcTLNj/25QO8gulHC5JtTzSE2UQ==
   dependencies:
-    mime-db "~1.27.0"
+    mime-db "1.45.0"
 
-mime-types@~2.1.16:
-  version "2.1.17"
-  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.17.tgz"
-  dependencies:
-    mime-db "~1.30.0"
-
-mime@1.4.1:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/mime/-/mime-1.4.1.tgz"
+mime@1.6.0:
+  version "1.6.0"
+  resolved "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz"
+  integrity sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==
 
 minimatch@^3.0.4:
   version "3.0.4"
@@ -356,9 +432,15 @@ ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz"
 
-negotiator@0.6.1:
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.1.tgz"
+ms@2.1.1:
+  version "2.1.1"
+  resolved "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz"
+  integrity sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==
+
+negotiator@0.6.2:
+  version "0.6.2"
+  resolved "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz"
+  integrity sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==
 
 on-finished@~2.3.0:
   version "2.3.0"
@@ -370,28 +452,42 @@ on-headers@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/on-headers/-/on-headers-1.0.1.tgz"
 
-parseurl@~1.3.2:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.2.tgz"
+parseurl@~1.3.2, parseurl@~1.3.3:
+  version "1.3.3"
+  resolved "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz"
+  integrity sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==
+
+path-is-absolute@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+  integrity sha1-F0uSaHNVNP+8es5r9TpanhtcX18=
 
 path-to-regexp@0.1.7:
   version "0.1.7"
-  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz"
+  resolved "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz"
+  integrity sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=
 
-proxy-addr@~2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-2.0.2.tgz"
+proxy-addr@~2.0.5:
+  version "2.0.6"
+  resolved "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.6.tgz"
+  integrity sha512-dh/frvCBVmSsDYzw6n926jv974gddhkFPfiN8hPOi30Wax25QZyZEGveluCgliBnqmuM+UJmBErbAUFIoDbjOw==
   dependencies:
     forwarded "~0.1.2"
-    ipaddr.js "1.5.2"
+    ipaddr.js "1.9.1"
 
 qs@6.5.1, qs@^6.5.1:
   version "6.5.1"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.1.tgz"
 
-range-parser@~1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.0.tgz"
+qs@6.7.0:
+  version "6.7.0"
+  resolved "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz"
+  integrity sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==
+
+range-parser@~1.2.1:
+  version "1.2.1"
+  resolved "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz"
+  integrity sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==
 
 raw-body@2.3.2:
   version "2.3.2"
@@ -402,27 +498,61 @@ raw-body@2.3.2:
     iconv-lite "0.4.19"
     unpipe "1.0.0"
 
+raw-body@2.4.0:
+  version "2.4.0"
+  resolved "https://registry.npmjs.org/raw-body/-/raw-body-2.4.0.tgz"
+  integrity sha512-4Oz8DUIwdvoa5qMJelxipzi/iJIi40O5cGV1wNYp5hvZP8ZN0T+jiNkL0QepXs+EsQ9XJ8ipEDoiH70ySUJP3Q==
+  dependencies:
+    bytes "3.1.0"
+    http-errors "1.7.2"
+    iconv-lite "0.4.24"
+    unpipe "1.0.0"
+
+router@2.0.0-alpha.1:
+  version "2.0.0-alpha.1"
+  resolved "https://registry.npmjs.org/router/-/router-2.0.0-alpha.1.tgz"
+  integrity sha512-fz/T/qLkJM6RTtbqGqA1+uZ88ejqJoPyKeJAeXPYjebA7HzV/UyflH4gXWqW/Y6SERnp4kDwNARjqy6se3PcOw==
+  dependencies:
+    array-flatten "2.1.1"
+    debug "3.1.0"
+    methods "~1.1.2"
+    parseurl "~1.3.2"
+    path-to-regexp "0.1.7"
+    setprototypeof "1.1.0"
+    utils-merge "1.0.1"
+
 safe-buffer@5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz"
 
-send@0.16.1:
-  version "0.16.1"
-  resolved "https://registry.yarnpkg.com/send/-/send-0.16.1.tgz"
+safe-buffer@5.1.2:
+  version "5.1.2"
+  resolved "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz"
+  integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
+
+"safer-buffer@>= 2.1.2 < 3":
+  version "2.1.2"
+  resolved "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz"
+  integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
+
+send@0.17.1:
+  version "0.17.1"
+  resolved "https://registry.npmjs.org/send/-/send-0.17.1.tgz"
+  integrity sha512-BsVKsiGcQMFwT8UxypobUKyv7irCNRHk1T0G680vk88yf6LBByGcZJOTJCrTP2xVN6yI+XjPJcNuE3V4fT9sAg==
   dependencies:
     debug "2.6.9"
-    depd "~1.1.1"
+    depd "~1.1.2"
     destroy "~1.0.4"
-    encodeurl "~1.0.1"
+    encodeurl "~1.0.2"
     escape-html "~1.0.3"
     etag "~1.8.1"
     fresh "0.5.2"
-    http-errors "~1.6.2"
-    mime "1.4.1"
-    ms "2.0.0"
+    http-errors "~1.7.2"
+    mime "1.6.0"
+    ms "2.1.1"
     on-finished "~2.3.0"
-    range-parser "~1.2.0"
-    statuses "~1.3.1"
+    range-parser "~1.2.1"
+    statuses "~1.5.0"
 
 serve-favicon@~2.4.5:
   version "2.4.5"
@@ -434,14 +564,15 @@ serve-favicon@~2.4.5:
     parseurl "~1.3.2"
     safe-buffer "5.1.1"
 
-serve-static@1.13.1:
-  version "1.13.1"
-  resolved "https://registry.yarnpkg.com/serve-static/-/serve-static-1.13.1.tgz"
+serve-static@1.14.1:
+  version "1.14.1"
+  resolved "https://registry.npmjs.org/serve-static/-/serve-static-1.14.1.tgz"
+  integrity sha512-JMrvUwE54emCYWlTI+hGrGv5I8dEwmco/00EvkzIIsR7MqrHonbD9pO2MOfFnpFntl7ecpZs+3mW+XbQZu9QCg==
   dependencies:
-    encodeurl "~1.0.1"
+    encodeurl "~1.0.2"
     escape-html "~1.0.3"
-    parseurl "~1.3.2"
-    send "0.16.1"
+    parseurl "~1.3.3"
+    send "0.17.1"
 
 setprototypeof@1.0.3:
   version "1.0.3"
@@ -449,11 +580,18 @@ setprototypeof@1.0.3:
 
 setprototypeof@1.1.0:
   version "1.1.0"
-  resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.1.0.tgz"
+  resolved "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz"
+  integrity sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==
 
-"statuses@>= 1.3.1 < 2", statuses@~1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.3.1.tgz"
+setprototypeof@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz"
+  integrity sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==
+
+"statuses@>= 1.3.1 < 2", "statuses@>= 1.5.0 < 2", statuses@~1.5.0:
+  version "1.5.0"
+  resolved "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz"
+  integrity sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=
 
 supports-color@^5.3.0:
   version "5.5.0"
@@ -462,12 +600,18 @@ supports-color@^5.3.0:
   dependencies:
     has-flag "^3.0.0"
 
-type-is@~1.6.15:
-  version "1.6.15"
-  resolved "https://registry.yarnpkg.com/type-is/-/type-is-1.6.15.tgz"
+toidentifier@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz"
+  integrity sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==
+
+type-is@~1.6.15, type-is@~1.6.17, type-is@~1.6.18:
+  version "1.6.18"
+  resolved "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz"
+  integrity sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==
   dependencies:
     media-typer "0.3.0"
-    mime-types "~2.1.15"
+    mime-types "~2.1.24"
 
 unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"


### PR DESCRIPTION
The site is now accessible at the following urls, where `:definition` represents the `id` of a past definition text block in the parent channel.
- `/`
- `/channels/967831`
- `/blocks/10710988`
- `/:definition/`
- `/:definition/channels/967831`
- `/:definition/blocks/10710988`

When `:definition` is not defined, the most recently updated definition is displayed. The logic for populating the definition template locals from the url slug is in `/middleware/definitions.js`.

---

Miscellaneous changes:
- moved `<%- include('partials/definition'); -%>` out of main blocks loop to ensure only one definition is added
- replace Promise-based asynchronous code with async / await for easier readability / editing
- make block template logic more robust by filtering types based on class (e.g. `block.class == 'Text'`)
- add `date-fns/format` to format dates, see https://date-fns.org/v2.17.0/docs/format for options
- fix error handling to show error message and stack in development