### PR TITLE
fix definition path match function

### DIFF
--- a/middleware/definitions.js
+++ b/middleware/definitions.js
@@ -2,7 +2,7 @@ const { match } = require("path-to-regexp");
 const Arena = require('are.na');
 
 const { ARENA_CHANNEL_ID } = process.env;
-const matchPathDefinition = match('/:definition(\\d+)', { decode: decodeURIComponent });
+const matchPathDefinition = match('/:definition(\\d+)', { decode: decodeURIComponent, end: false });
 
 module.exports = async (req, res, next) => {
 
@@ -33,7 +33,6 @@ module.exports = async (req, res, next) => {
     definition = definitions[0];
     definitionPathPrefix = '';
   }
-  
   // expose definition(s) on template locals
   res.locals.definition = definition;
   res.locals.definitionPathPrefix = definitionPathPrefix;

--- a/views/channel.ejs
+++ b/views/channel.ejs
@@ -1,7 +1,7 @@
 <%- include('partials/header'); -%>
 <main id="channel">
   <h1 class="page-title">
-    notes towards <a href="/">a syn-site</a>: <%= title %>
+    notes towards <a href="<%= `${definitionPathPrefix}/` %>">a syn-site</a>: <%= title %>
   </h1>
   <div class="grid">
     <%- include('partials/definition', { block: definition, definitionPathPrefix, definitions }); -%>

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -1,7 +1,7 @@
 <%- include('partials/header'); -%>
 <main id="index">
   <h1 class="page-title">
-    notes towards <a href="/">a syn-site</a>
+    notes towards <a href="<%= `${definitionPathPrefix}/` %>">a syn-site</a>
   </h1>
   <div class="grid">
     <%- include('partials/definition', { block: definition, definitionPathPrefix, definitions }); -%>

--- a/views/show.ejs
+++ b/views/show.ejs
@@ -1,7 +1,7 @@
 <%- include('partials/header'); -%>
 <main id="show">
   <h1 class="page-title">
-        notes towards <a href="/">a syn-site</a>: <%= title %>
+        notes towards <a href="<%= `${definitionPathPrefix}/` %>">a syn-site</a>: <%= title %>
   </h1>
   <div class="block">
     <% if (embed) { %>


### PR DESCRIPTION
The match function which checks if there is a definition block id in the url path was looking for exact matches, rather than any url that *starts* with a definition. Added `end: false` to the options per the [documentation](https://github.com/pillarjs/path-to-regexp#usage).

```js
const matchPathDefinition = match('/:definition(\\d+)', { decode: decodeURIComponent, end: false });
```

Also, added the `definitionPathPrefix to all of the page title homepage links, so that you stay within a definition version until you click on a different definition version.